### PR TITLE
Generated register.go and types files

### DIFF
--- a/apis/resourcecontrollerv2/v1alpha1/register.go
+++ b/apis/resourcecontrollerv2/v1alpha1/register.go
@@ -37,7 +37,7 @@ var (
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
 )
 
-// Resourcecontrollerv2 types metadata.
+// resourcecontrollerv2 types metadata.
 var (
 	ResourceInstanceKind             = reflect.TypeOf(ResourceInstance{}).Name()
 	ResourceInstanceGroupKind        = schema.GroupKind{Group: Group, Kind: ResourceInstanceKind}.String()

--- a/apis/resourcecontrollerv2/v1alpha1/resourceinstance_types.go
+++ b/apis/resourcecontrollerv2/v1alpha1/resourceinstance_types.go
@@ -23,13 +23,10 @@ import (
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 )
 
-// In spec mandatory fields should be by value, and optional fields pointers
-// In status, all fields should be by value, except timestamps - metav1.Time, and runtime.RawExtension which requires special treatment
-// https://github.com/crossplane/crossplane/blob/master/design/one-pager-managed-resource-api-design.md#pointer-types-and-markers
-
 // ResourceInstanceParameters are the configurable fields of a ResourceInstance.
 type ResourceInstanceParameters struct {
-	// An human-readable name of the instance.
+	// The name of the instance. Must be 180 characters or less and cannot include any special characters other than
+	// `(space) - . _ :`.
 	Name string `json:"name"`
 
 	// The deployment location where the instance should be hosted.
@@ -92,7 +89,7 @@ type ResourceInstanceObservation struct {
 	// The long ID (full CRN) of the resource group.
 	ResourceGroupCrn string `json:"resourceGroupCrn,omitempty"`
 
-	// ResourceID is the unique ID of the offering. This value is provided by and stored in the global catalog.
+	// The unique ID of the offering. This value is provided by and stored in the global catalog.
 	ResourceID string `json:"resourceId,omitempty"`
 
 	// The unique ID of the plan associated with the offering. This value is provided by and stored in the global catalog.

--- a/apis/resourcecontrollerv2/v1alpha1/resourceinstance_types.go
+++ b/apis/resourcecontrollerv2/v1alpha1/resourceinstance_types.go
@@ -35,7 +35,8 @@ type ResourceInstanceParameters struct {
 
 	// The name of the resource group where the instance is deployed
 	// +immutable
-	ResourceGroupName string `json:"resourceGroupName"`
+	// +optional
+	ResourceGroupName string `json:"resourceGroupName,omitempty"`
 
 	// The name of the service offering like cloud-object-storage, kms etc
 	// +immutable
@@ -57,11 +58,6 @@ type ResourceInstanceParameters struct {
 	// Configuration options represented as key-value pairs that are passed through to the target resource brokers.
 	// +optional
 	Parameters *runtime.RawExtension `json:"parameters,omitempty"`
-
-	// Indicates if the resource instance is locked for further update or delete operations. It does not affect actions
-	// performed on child resources like aliases, bindings or keys. False by default.
-	// +optional
-	EntityLock *string `json:"entityLock,omitempty"`
 }
 
 // ResourceInstanceObservation are the observable fields of a ResourceInstance.
@@ -71,7 +67,7 @@ type ResourceInstanceObservation struct {
 
 	// When you create a new resource, a globally unique identifier (GUID) is assigned. This GUID is a unique internal
 	// identifier managed by the resource controller that corresponds to the instance.
-	GUID string `json:"guid,omitempty"`
+	Guid string `json:"guid,omitempty"`
 
 	// The full Cloud Resource Name (CRN) associated with the instance. For more information about this format, see [Cloud
 	// Resource Names](https://cloud.ibm.com/docs/overview?topic=overview-crn).
@@ -107,6 +103,9 @@ type ResourceInstanceObservation struct {
 
 	// The sub-type of instance, e.g. `cfaas`.
 	SubType string `json:"subType,omitempty"`
+
+	// A boolean that dictates if the resource instance is locked or not.
+	Locked bool `json:"locked,omitempty"`
 
 	// The status of the last operation requested on the instance.
 	LastOperation *runtime.RawExtension `json:"lastOperation,omitempty"`

--- a/apis/resourcecontrollerv2/v1alpha1/resourcekey_types.go
+++ b/apis/resourcecontrollerv2/v1alpha1/resourcekey_types.go
@@ -66,7 +66,7 @@ type ResourceKeyObservation struct {
 
 	// When you create a new key, a globally unique identifier (GUID) is assigned. This GUID is a unique internal
 	// identifier managed by the resource controller that corresponds to the key.
-	GUID string `json:"guid,omitempty"`
+	Guid string `json:"guid,omitempty"`
 
 	// The full Cloud Resource Name (CRN) associated with the key. For more information about this format, see [Cloud
 	// Resource Names](https://cloud.ibm.com/docs/overview?topic=overview-crn).
@@ -80,6 +80,9 @@ type ResourceKeyObservation struct {
 
 	// The short ID of the resource group.
 	ResourceGroupID string `json:"resourceGroupId,omitempty"`
+
+	// The CRN of resource instance or alias associated to the key.
+	SourceCrn string `json:"sourceCrn,omitempty"`
 
 	// The state of the key.
 	State string `json:"state,omitempty"`

--- a/apis/resourcecontrollerv2/v1alpha1/resourcekey_types.go
+++ b/apis/resourcecontrollerv2/v1alpha1/resourcekey_types.go
@@ -22,25 +22,22 @@ import (
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 )
 
-// In spec mandatory fields should be by value, and optional fields pointers
-// In status, all fields should be by value, except timestamps - metav1.Time, and runtime.RawExtension which requires special treatment
-// https://github.com/crossplane/crossplane/blob/master/design/one-pager-managed-resource-api-design.md#pointer-types-and-markers
-
 // ResourceKeyParameters are the configurable fields of a ResourceKey.
 type ResourceKeyParameters struct {
-	// The human-readable name of the key.
-	Name string `json:"name,omitempty"`
+	// The name of the key.
+	Name string `json:"name"`
 
 	// The short or long ID of resource instance or alias.
 	// +immutable
+	// +optional
 	Source *string `json:"source,omitempty"`
 
-	// SourceRef is a reference to a resource instance used to set Source
+	// A reference to a resource used to set Source
 	// +immutable
 	// +optional
 	SourceRef *runtimev1alpha1.Reference `json:"sourceRef,omitempty"`
 
-	// SourceSelector selects a reference to a resource instance used to set Source.
+	// SourceSelector selects a reference to a resource used to set Source
 	// +immutable
 	// +optional
 	SourceSelector *runtimev1alpha1.Selector `json:"sourceSelector,omitempty"`
@@ -103,13 +100,13 @@ type ResourceKeyObservation struct {
 	DeletedAt *metav1.Time `json:"deletedAt,omitempty"`
 
 	// The subject who created the key.
-	CreatedBy string `json:"created_by,omitempty"`
+	CreatedBy string `json:"createdBy,omitempty"`
 
 	// The subject who updated the key.
-	UpdatedBy string `json:"updated_by,omitempty"`
+	UpdatedBy string `json:"updatedBy,omitempty"`
 
 	// The subject who deleted the key.
-	DeletedBy string `json:"deleted_by,omitempty"`
+	DeletedBy string `json:"deletedBy,omitempty"`
 }
 
 // A ResourceKeySpec defines the desired state of a ResourceKey.

--- a/pkg/clients/resourceinstance/resourceinstance.go
+++ b/pkg/clients/resourceinstance/resourceinstance.go
@@ -28,16 +28,16 @@ const (
 	errGetResGroupID        = "error getting resource group ID"
 )
 
-// LateInitializeSpec fills optional and unsassigned fields with the values in *rcv2.ResourceInstance object.
+// LateInitializeSpec fills optional and unassigned fields with the values in *rcv2.ResourceInstance object.
 func LateInitializeSpec(client ibmc.ClientSession, spec *v1alpha1.ResourceInstanceParameters, in *rcv2.ResourceInstance) error { // nolint:gocyclo
 	if spec.AllowCleanup == nil {
 		spec.AllowCleanup = in.AllowCleanup
 	}
-	if spec.EntityLock == nil {
-		spec.EntityLock = reference.ToPtrValue(strconv.FormatBool(*in.Locked))
-	}
 	if spec.Parameters == nil {
 		spec.Parameters = ibmc.MapToRawExtension(in.Parameters)
+	}
+	if spec.EntityLock == nil {
+		spec.EntityLock = reference.ToPtrValue(strconv.FormatBool(*in.Locked))
 	}
 	if spec.Tags == nil {
 		tags, err := ibmc.GetResourceInstanceTags(client, reference.FromPtrValue(in.TargetCrn))
@@ -49,76 +49,76 @@ func LateInitializeSpec(client ibmc.ClientSession, spec *v1alpha1.ResourceInstan
 	return nil
 }
 
-// GenerateCreateResourceInstanceOptions produces ResourceInstanceOptions object from ResourceInstanceParameters object.
+// GenerateCreateResourceInstanceOptions produces CreateResourceInstanceOptions object from ResourceInstanceParameters object.
 func GenerateCreateResourceInstanceOptions(client ibmc.ClientSession, in v1alpha1.ResourceInstanceParameters, o *rcv2.CreateResourceInstanceOptions) error {
-	rPlanID, err := ibmc.GetResourcePlanID(client, in.ServiceName, in.ResourcePlanName)
-	if err != nil {
-		return errors.Wrap(err, errGetResPlaID)
-	}
-
 	rgID, err := ibmc.GetResourceGroupID(client, in.ResourceGroupName)
 	if err != nil {
 		return errors.Wrap(err, errGetResGroupID)
 	}
 
+	rPlanID, err := ibmc.GetResourcePlanID(client, in.ServiceName, in.ResourcePlanName)
+	if err != nil {
+		return errors.Wrap(err, errGetResPlaID)
+	}
+
 	o.Name = reference.ToPtrValue(in.Name)
-	o.Tags = in.Tags
-	o.ResourcePlanID = rPlanID
-	o.ResourceGroup = rgID
 	o.Target = reference.ToPtrValue(in.Target)
+	o.ResourceGroup = rgID
+	o.ResourcePlanID = rPlanID
+	o.Tags = in.Tags
 	o.AllowCleanup = in.AllowCleanup
-	o.EntityLock = in.EntityLock
 	o.Parameters = ibmc.RawExtensionToMap(in.Parameters)
+	o.EntityLock = in.EntityLock
 	return nil
 }
 
-// GenerateUpdateResourceInstanceOptions produces UpdateResourceInstanceOptions object from ResourceInstance object.
+// GenerateUpdateResourceInstanceOptions produces UpdateResourceInstanceOptions object from ResourceInstanceParameters object.
 func GenerateUpdateResourceInstanceOptions(client ibmc.ClientSession, id string, in v1alpha1.ResourceInstanceParameters, o *rcv2.UpdateResourceInstanceOptions) error {
 	rPlanID, err := ibmc.GetResourcePlanID(client, in.ServiceName, in.ResourcePlanName)
 	if err != nil {
 		return errors.Wrap(err, errGetResPlaID)
 	}
 
+	o.ID = reference.ToPtrValue(id)
 	o.Name = reference.ToPtrValue(in.Name)
+	o.Parameters = ibmc.RawExtensionToMap(in.Parameters)
 	o.ResourcePlanID = rPlanID
 	o.AllowCleanup = in.AllowCleanup
-	o.ID = reference.ToPtrValue(id)
-	o.Parameters = ibmc.RawExtensionToMap(in.Parameters)
 	return nil
 }
 
 // GenerateObservation produces ResourceInstanceObservation object from *rcv2.ResourceInstance object.
 func GenerateObservation(client ibmc.ClientSession, in *rcv2.ResourceInstance) (v1alpha1.ResourceInstanceObservation, error) {
 	o := v1alpha1.ResourceInstanceObservation{
-		AccountID:           reference.FromPtrValue(in.AccountID),
-		CreatedAt:           ibmc.DateTimeToMetaV1Time(in.CreatedAt),
-		Crn:                 reference.FromPtrValue(in.Crn),
-		DashboardURL:        reference.FromPtrValue(in.DashboardURL),
-		DeletedAt:           ibmc.DateTimeToMetaV1Time(in.DeletedAt),
-		GUID:                reference.FromPtrValue(in.Guid),
 		ID:                  reference.FromPtrValue(in.ID),
+		GUID:                reference.FromPtrValue(in.Guid),
+		Crn:                 reference.FromPtrValue(in.Crn),
+		URL:                 reference.FromPtrValue(in.URL),
+		AccountID:           reference.FromPtrValue(in.AccountID),
+		ResourceGroupID:     reference.FromPtrValue(in.ResourceGroupID),
+		ResourceGroupCrn:    reference.FromPtrValue(in.ResourceGroupCrn),
+		ResourceID:          reference.FromPtrValue(in.ResourceID),
+		ResourcePlanID:      reference.FromPtrValue(in.ResourcePlanID),
+		TargetCrn:           reference.FromPtrValue(in.TargetCrn),
+		State:               reference.FromPtrValue(in.State),
+		Type:                reference.FromPtrValue(in.Type),
+		SubType:             reference.FromPtrValue(in.SubType),
 		LastOperation:       ibmc.MapToRawExtension(in.LastOperation),
+		DashboardURL:        reference.FromPtrValue(in.DashboardURL),
 		PlanHistory:         GeneratePlanHistory(in.PlanHistory),
 		ResourceAliasesURL:  reference.FromPtrValue(in.ResourceAliasesURL),
 		ResourceBindingsURL: reference.FromPtrValue(in.ResourceBindingsURL),
-		ResourceGroupCrn:    reference.FromPtrValue(in.ResourceGroupCrn),
-		ResourceGroupID:     reference.FromPtrValue(in.ResourceGroupID),
-		ResourceID:          reference.FromPtrValue(in.ResourceID),
 		ResourceKeysURL:     reference.FromPtrValue(in.ResourceKeysURL),
-		ResourcePlanID:      reference.FromPtrValue(in.ResourcePlanID),
-		State:               reference.FromPtrValue(in.State),
-		SubType:             reference.FromPtrValue(in.SubType),
-		TargetCrn:           reference.FromPtrValue(in.TargetCrn),
-		Type:                reference.FromPtrValue(in.Type),
-		URL:                 reference.FromPtrValue(in.URL),
-		UpdatedAt:           ibmc.DateTimeToMetaV1Time(in.UpdatedAt),
+		CreatedAt:           ibmc.DateTimeToMetaV1Time(in.CreatedAt),
 		CreatedBy:           reference.FromPtrValue(in.CreatedBy),
+		UpdatedAt:           ibmc.DateTimeToMetaV1Time(in.UpdatedAt),
+		UpdatedBy:           reference.FromPtrValue(in.UpdatedBy),
+		DeletedAt:           ibmc.DateTimeToMetaV1Time(in.DeletedAt),
 		DeletedBy:           reference.FromPtrValue(in.DeletedBy),
-		RestoredAt:          ibmc.DateTimeToMetaV1Time(in.RestoredAt),
-		RestoredBy:          reference.FromPtrValue(in.RestoredBy),
 		ScheduledReclaimAt:  ibmc.DateTimeToMetaV1Time(in.ScheduledReclaimAt),
 		ScheduledReclaimBy:  reference.FromPtrValue(in.ScheduledReclaimBy),
-		UpdatedBy:           reference.FromPtrValue(in.UpdatedBy),
+		RestoredAt:          ibmc.DateTimeToMetaV1Time(in.RestoredAt),
+		RestoredBy:          reference.FromPtrValue(in.RestoredBy),
 	}
 	// ServiceEndpoints can be found in instance.Parameters["service-endpoints"]
 	return o, nil
@@ -136,20 +136,25 @@ func GenerateTarget(in *rcv2.ResourceInstance) string {
 	return crn.Region
 }
 
-// GeneratePlanHistory generates v1alpha1.PlanHistoryItem[] from []rcv2.PlanHistoryItem
+// GeneratePlanHistory generates []v1alpha1.PlanHistoryItem from []rcv2.PlanHistoryItem
 func GeneratePlanHistory(in []rcv2.PlanHistoryItem) []v1alpha1.PlanHistoryItem {
 	if in == nil {
 		return nil
 	}
 	o := make([]v1alpha1.PlanHistoryItem, 0)
 	for _, phi := range in {
-		item := v1alpha1.PlanHistoryItem{
-			ResourcePlanID: reference.FromPtrValue(phi.ResourcePlanID),
-			StartDate:      ibmc.DateTimeToMetaV1Time(phi.StartDate),
-		}
-		o = append(o, item)
+		o = append(o, GeneratePlanHistoryItem(phi))
 	}
 	return o
+}
+
+// GeneratePlanHistoryItem generates v1alpha1.PlanHistoryItem from rcv2.PlanHistoryItem
+func GeneratePlanHistoryItem(in rcv2.PlanHistoryItem) v1alpha1.PlanHistoryItem {
+	planHistoryItem := v1alpha1.PlanHistoryItem{
+		ResourcePlanID: reference.FromPtrValue(in.ResourcePlanID),
+		StartDate:      ibmc.DateTimeToMetaV1Time(in.StartDate),
+	}
+	return planHistoryItem
 }
 
 // IsUpToDate checks whether current state is up-to-date compared to the given set of parameters.
@@ -167,28 +172,33 @@ func IsUpToDate(client ibmc.ClientSession, in *v1alpha1.ResourceInstanceParamete
 
 // GenerateResourceInstanceParameters generates service instance parameters from resource instance
 func GenerateResourceInstanceParameters(client ibmc.ClientSession, in *rcv2.ResourceInstance) (*v1alpha1.ResourceInstanceParameters, error) {
-	o := &v1alpha1.ResourceInstanceParameters{
-		Name:         reference.FromPtrValue(in.Name),
-		Target:       GenerateTarget(in),
-		AllowCleanup: in.AllowCleanup,
-		EntityLock:   reference.ToPtrValue(strconv.FormatBool(*in.Locked)),
-		ServiceName:  ibmc.GetServiceName(in),
-		Parameters:   ibmc.MapToRawExtension(in.Parameters),
-	}
+
 	rgName, err := ibmc.GetResourceGroupName(client, reference.FromPtrValue(in.ResourceGroupID))
 	if err != nil {
 		return nil, err
 	}
-	o.ResourceGroupName = rgName
-	pName, err := ibmc.GetResourcePlanName(client, o.ServiceName, reference.FromPtrValue(in.ResourcePlanID))
+
+	sName := ibmc.GetServiceName(in)
+	pName, err := ibmc.GetResourcePlanName(client, sName, reference.FromPtrValue(in.ResourcePlanID))
 	if err != nil {
 		return nil, err
 	}
-	o.ResourcePlanName = reference.FromPtrValue(pName)
+
 	tags, err := ibmc.GetResourceInstanceTags(client, reference.FromPtrValue(in.Crn))
 	if err != nil {
 		return nil, err
 	}
-	o.Tags = tags
+
+	o := &v1alpha1.ResourceInstanceParameters{
+		Name:              reference.FromPtrValue(in.Name),
+		Target:            GenerateTarget(in),
+		ResourceGroupName: rgName,
+		ServiceName:       sName,
+		ResourcePlanName:  reference.FromPtrValue(pName),
+		AllowCleanup:      in.AllowCleanup,
+		Parameters:        ibmc.MapToRawExtension(in.Parameters),
+		Tags:              tags,
+		EntityLock:        reference.ToPtrValue(strconv.FormatBool(*in.Locked)),
+	}
 	return o, nil
 }

--- a/pkg/clients/resourcekey/resourcekey.go
+++ b/pkg/clients/resourcekey/resourcekey.go
@@ -2,14 +2,10 @@ package resourcekey
 
 import (
 	"fmt"
-	"time"
 
-	"github.com/go-openapi/strfmt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/jeremywohl/flatten"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -65,27 +61,17 @@ func GenerateObservation(in *rcv2.ResourceKey) (v1alpha1.ResourceKeyObservation,
 		IamCompatible:       ibmc.BoolValue(in.IamCompatible),
 		ResourceInstanceURL: reference.FromPtrValue(in.ResourceInstanceURL),
 		UpdatedBy:           reference.FromPtrValue(in.UpdatedBy),
-		CreatedAt:           GenerateMetaV1Time(in.CreatedAt),
+		CreatedAt:           ibmc.DateTimeToMetaV1Time(in.CreatedAt),
 		Crn:                 reference.FromPtrValue(in.Crn),
-		DeletedAt:           GenerateMetaV1Time(in.DeletedAt),
+		DeletedAt:           ibmc.DateTimeToMetaV1Time(in.DeletedAt),
 		GUID:                reference.FromPtrValue(in.Guid),
 		ID:                  reference.FromPtrValue(in.ID),
 		ResourceGroupID:     reference.FromPtrValue(in.ResourceGroupID),
 		State:               reference.FromPtrValue(in.State),
 		URL:                 reference.FromPtrValue(in.URL),
-		UpdatedAt:           GenerateMetaV1Time(in.UpdatedAt),
+		UpdatedAt:           ibmc.DateTimeToMetaV1Time(in.UpdatedAt),
 	}
 	return o, nil
-}
-
-// GenerateMetaV1Time converts strfmt.DateTime to metav1.Time
-// TODO - extract this to parent `clients` package
-func GenerateMetaV1Time(t *strfmt.DateTime) *metav1.Time {
-	if t == nil {
-		return nil
-	}
-	tx := metav1.NewTime(time.Time(*t))
-	return &tx
 }
 
 // IsUpToDate checks whether current state is up-to-date compared to the given

--- a/pkg/clients/resourcekey/resourcekey_test.go
+++ b/pkg/clients/resourcekey/resourcekey_test.go
@@ -135,7 +135,7 @@ func observation(m ...func(*v1alpha1.ResourceKeyObservation)) *v1alpha1.Resource
 		CreatedBy:           createdBy,
 		DeletedBy:           "",
 		IamCompatible:       iamCompatible,
-		CreatedAt:           GenerateMetaV1Time(&createdAt),
+		CreatedAt:           ibmc.DateTimeToMetaV1Time(&createdAt),
 		Crn:                 resCrn,
 		DeletedAt:           nil,
 		GUID:                guid,
@@ -144,7 +144,7 @@ func observation(m ...func(*v1alpha1.ResourceKeyObservation)) *v1alpha1.Resource
 		ResourceInstanceURL: resInstURL,
 		State:               state,
 		URL:                 url,
-		UpdatedAt:           GenerateMetaV1Time(&createdAt),
+		UpdatedAt:           ibmc.DateTimeToMetaV1Time(&createdAt),
 		UpdatedBy:           createdBy,
 	}
 

--- a/pkg/controller/resourcecontrollerv2/resourcekey_test.go
+++ b/pkg/controller/resourcecontrollerv2/resourcekey_test.go
@@ -114,7 +114,7 @@ func rkWithResourceInstanceURL(s string) keyModifier {
 
 func rkWithCreatedAt(t strfmt.DateTime) keyModifier {
 	return func(i *v1alpha1.ResourceKey) {
-		i.Status.AtProvider.CreatedAt = ibmcrk.GenerateMetaV1Time(&t)
+		i.Status.AtProvider.CreatedAt = ibmc.DateTimeToMetaV1Time(&t)
 	}
 }
 


### PR DESCRIPTION
This PR contains the generated code for the Resource Controller `register.go` and the "_types" files. It mostly matches the handwritten code.

I don't expect that we will merge this PR, but I think it will be a good vehicle to identify and discuss any further changes that are needed.